### PR TITLE
refactor(i18n): fix inconsistencies and improve type safety

### DIFF
--- a/src/i18n/locale.test.ts
+++ b/src/i18n/locale.test.ts
@@ -28,7 +28,7 @@ describe("getLang", () => {
   });
 });
 
-describe("useTranslations", () => {
+describe("getTranslations", () => {
   test("returns a function", () => {
     const t = getTranslations("pl");
     expect(typeof t).toBe("function");

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -21,15 +21,16 @@ export const locales = Object.keys(languages) as Lang[];
  */
 export type TranslationKey = keyof typeof pl;
 
-// Compile-time parity checks: fail if any language is missing or has extra keys.
-const _enParity: Record<TranslationKey, string> = en;
-const _deParity: Record<TranslationKey, string> = de;
-
-export const ui: Record<Lang, Record<TranslationKey, string>> = {
-  pl,
-  en,
-  de,
-};
+/**
+ * All UI translations indexed by locale.
+ * The `satisfies` clause enforces compile-time parity: every language must
+ * provide exactly the same set of keys as the default language (no missing,
+ * no extra keys allowed).
+ */
+export const ui = { pl, en, de } satisfies Record<
+  Lang,
+  Record<TranslationKey, string>
+>;
 
 /**
  * Resolves `Astro.currentLocale` to a valid `Lang`.

--- a/src/i18n/path.test.ts
+++ b/src/i18n/path.test.ts
@@ -7,7 +7,7 @@ import {
   stripLocalePrefix,
 } from "./path";
 
-describe("useTranslatedPath", () => {
+describe("getTranslatedPath", () => {
   test("returns a function", () => {
     const translatePath = getTranslatedPath("pl");
     expect(typeof translatePath).toBe("function");
@@ -61,7 +61,7 @@ describe("useTranslatedPath", () => {
   });
 });
 
-describe("getRouteFromUrl", () => {
+describe("getRoute", () => {
   test("returns canonical key for a German translated slug", () => {
     const url = new URL("https://example.com/de/datenschutzerklarung");
     expect(getRoute(url)).toBe("privacy-policy");

--- a/src/i18n/path.ts
+++ b/src/i18n/path.ts
@@ -71,15 +71,18 @@ export function getCanonicalUrl(
 /**
  * Returns hreflang alternate URLs for all configured locales.
  * Uses translated paths for known routes, locale-prefixed paths otherwise.
+ * Returns fully-qualified absolute URLs as recommended by search engines.
  */
 export function getAlternateUrls(
-  url: URL
+  url: URL,
+  site: URL | undefined
 ): Array<{ locale: Lang; href: string }> {
+  const siteUrl = getSiteUrl(site);
   const basePath = getCanonicalBasePath(url);
 
   return locales.map((locale) => {
     const tp = getTranslatedPath(locale);
-    return { locale, href: tp(basePath, locale) };
+    return { locale, href: `${siteUrl}${tp(basePath, locale)}` };
   });
 }
 

--- a/src/i18n/richtext.test.ts
+++ b/src/i18n/richtext.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { getRichText } from "./richtext";
 
-describe("useRichText", () => {
+describe("getRichText", () => {
   test("returns a function", () => {
     const richText = getRichText("pl");
     expect(typeof richText).toBe("function");

--- a/src/i18n/richtext.ts
+++ b/src/i18n/richtext.ts
@@ -19,7 +19,7 @@ export interface RichTextPart {
  *
  * @example
  * ```ts
- * const richText = useRichText("pl");
+ * const richText = getRichText("pl");
  * const parts = richText("hero.title", ["accent"]);
  * // [{ text: "Tapicerstwo w nowoczesnym wydaniu" }, { text: ".", tag: "accent" }]
  * ```

--- a/src/layouts/seo/seo-head.astro
+++ b/src/layouts/seo/seo-head.astro
@@ -23,7 +23,7 @@ const {
 } = Astro.props;
 
 const canonicalUrl = getCanonicalUrl(Astro.site, Astro.url);
-const alternateUrls = getAlternateUrls(Astro.url);
+const alternateUrls = getAlternateUrls(Astro.url, Astro.site);
 
 const ogLocale = getOgLocale(lang);
 const ogLocaleAlternates = alternateUrls
@@ -40,7 +40,7 @@ const ogLocaleAlternates = alternateUrls
 {alternateUrls.map(({ locale, href }) => (
   <link rel="alternate" hreflang={locale} href={href} />
 ))}
-<link rel="alternate" hreflang="x-default" href="/">
+<link rel="alternate" hreflang="x-default" href={`${siteUrl}/`}>
 
 <meta property="og:site_name" content={t("seo.title")}>
 <meta property="og:title" content={title}>

--- a/src/lib/content/sanity.ts
+++ b/src/lib/content/sanity.ts
@@ -1,4 +1,4 @@
-import type { Lang } from "@i18n/locale";
+import { defaultLang, type Lang } from "@i18n/locale";
 import type {
   SanityImageObjectStub,
   SanityImageSource,
@@ -45,7 +45,7 @@ export const sanityApi = {
     const query = /* groq */ `
     *[_type == "portfolio"] | order(date desc) [$start...$end]
     {
-      "title": coalesce(title[_key == $lang][0].value, title[_key == "pl"][0].value),
+      "title": coalesce(title[_key == $lang][0].value, title[_key == $defaultLang][0].value),
       "slug": slug[$lang].current,
       "date": date,
       images[] {
@@ -55,13 +55,14 @@ export const sanityApi = {
         crop,
         hotspot,
       },
-      "excerpt": coalesce(excerpt[_key == $lang][0].value, excerpt[_key == "pl"][0].value),
-      "description": coalesce(description[_key == $lang][0].value, description[_key == "pl"][0].value),
+      "excerpt": coalesce(excerpt[_key == $lang][0].value, excerpt[_key == $defaultLang][0].value),
+      "description": coalesce(description[_key == $lang][0].value, description[_key == $defaultLang][0].value),
       "tags": tags
     }`;
 
     const entries = await sanityClient.fetch<RawPortfolioEntry[]>(query, {
       lang,
+      defaultLang,
       ...page,
     });
 
@@ -78,7 +79,7 @@ export const sanityApi = {
     const query = /* groq */ `
     *[_type == "portfolio"] | order(date desc) [0...$limit]
     {
-      "title": coalesce(title[_key == $lang][0].value, title[_key == "pl"][0].value),
+      "title": coalesce(title[_key == $lang][0].value, title[_key == $defaultLang][0].value),
       "slug": slug[$lang].current,
       "date": date,
       images[] {
@@ -88,13 +89,14 @@ export const sanityApi = {
         crop,
         hotspot,
       },
-      "excerpt": coalesce(excerpt[_key == $lang][0].value, excerpt[_key == "pl"][0].value),
-      "description": coalesce(description[_key == $lang][0].value, description[_key == "pl"][0].value),
+      "excerpt": coalesce(excerpt[_key == $lang][0].value, excerpt[_key == $defaultLang][0].value),
+      "description": coalesce(description[_key == $lang][0].value, description[_key == $defaultLang][0].value),
       "tags": tags
     }`;
 
     const entries = await sanityClient.fetch<RawPortfolioEntry[]>(query, {
       lang,
+      defaultLang,
       limit,
     });
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,82 +1,19 @@
 ---
-import NotFoundSvg from "@assets/404.svg";
-import { getLang, getTranslations } from "@i18n/locale";
-import { getTranslatedPath } from "@i18n/path";
-import MainLayout from "@layouts/main-layout.astro";
-import { LuHouse } from "react-icons/lu";
+import { defaultLang, type Lang, locales } from "@i18n/locale";
 
-export const prerender = true;
+/**
+ * Root-level 404 handler (SSR).
+ * Detects the locale from the request URL and redirects to the
+ * corresponding locale-specific 404 page at /[locale]/404.
+ */
+export const prerender = false;
 
-const lang = getLang(Astro.currentLocale);
-const t = getTranslations(lang);
-const tp = getTranslatedPath(lang);
+const localeFromUrl = Astro.url.pathname.split("/")[1];
+const locale: Lang =
+  localeFromUrl && locales.includes(localeFromUrl as Lang)
+    ? (localeFromUrl as Lang)
+    : defaultLang;
+
+return Astro.redirect(`/${locale}/404`, 302);
 ---
 
-<MainLayout
-  title={`404 | ${t("seo.title")}`}
-  description={t("404.description")}
-  robots="noindex, follow"
-  mainClass="bg-secondary pt-36 pb-20"
->
-  <div
-    data-testid="not-found-page"
-    data-animate="not-found"
-    class="mx-auto flex max-w-4xl flex-col items-center px-4 text-center sm:px-6 lg:px-8"
-  >
-    <div class="mb-8">
-      <NotFoundSvg fill="var(--accent)" width={200} aria-hidden="true" />
-    </div>
-
-    <h1 class="mb-4 font-accent text-8xl leading-none text-accent md:text-9xl">
-      404
-    </h1>
-
-    <h2 class="mb-3 text-2xl font-medium md:text-3xl">{t("404.title")}</h2>
-
-    <div
-      data-animate="not-found-decoration"
-      class="mb-6 h-1 w-20 bg-accent"
-    ></div>
-
-    <p class="mb-10 max-w-md text-lg leading-relaxed text-muted-foreground">
-      {t("404.description")}
-    </p>
-
-    <a
-      href={tp("/")}
-      class="inline-flex items-center gap-2 rounded-lg bg-accent px-8 py-4 text-white shadow-lg transition-all duration-300 hover:bg-accent/90 hover:shadow-xl"
-    >
-      <LuHouse className="h-5 w-5" aria-hidden="true" />
-      {t("404.cta")}
-    </a>
-  </div>
-</MainLayout>
-
-<style>
-  @media (scripting: enabled) {
-    [data-animate="not-found"] {
-      opacity: 0;
-      transform: translateY(30px);
-    }
-    [data-animate="not-found-decoration"] {
-      transform: scaleX(0);
-      transform-origin: center;
-    }
-  }
-</style>
-
-<script>
-  import { animate, inView } from "motion";
-
-  inView(
-    "[data-animate='not-found']",
-    (element) => {
-      animate(element, { opacity: 1, y: 0 }, { duration: 0.8 });
-    },
-    { margin: "-50px" }
-  );
-
-  inView("[data-animate='not-found-decoration']", (element) => {
-    animate(element, { scaleX: 1 }, { duration: 0.8, delay: 0.3 });
-  });
-</script>

--- a/src/pages/[locale]/404.astro
+++ b/src/pages/[locale]/404.astro
@@ -1,0 +1,86 @@
+---
+import NotFoundSvg from "@assets/404.svg";
+import { getLang, getTranslations, locales } from "@i18n/locale";
+import { getTranslatedPath } from "@i18n/path";
+import MainLayout from "@layouts/main-layout.astro";
+import { LuHouse } from "react-icons/lu";
+
+export const prerender = true;
+
+export function getStaticPaths() {
+  return locales.map((locale) => ({ params: { locale } }));
+}
+
+const lang = getLang(Astro.currentLocale);
+const t = getTranslations(lang);
+const tp = getTranslatedPath(lang);
+---
+
+<MainLayout
+  title={`404 | ${t("seo.title")}`}
+  description={t("404.description")}
+  robots="noindex, follow"
+  mainClass="bg-secondary pt-36 pb-20"
+>
+  <div
+    data-testid="not-found-page"
+    data-animate="not-found"
+    class="mx-auto flex max-w-4xl flex-col items-center px-4 text-center sm:px-6 lg:px-8"
+  >
+    <div class="mb-8">
+      <NotFoundSvg fill="var(--accent)" width={200} aria-hidden="true" />
+    </div>
+
+    <h1 class="mb-4 font-accent text-8xl leading-none text-accent md:text-9xl">
+      404
+    </h1>
+
+    <h2 class="mb-3 text-2xl font-medium md:text-3xl">{t("404.title")}</h2>
+
+    <div
+      data-animate="not-found-decoration"
+      class="mb-6 h-1 w-20 bg-accent"
+    ></div>
+
+    <p class="mb-10 max-w-md text-lg leading-relaxed text-muted-foreground">
+      {t("404.description")}
+    </p>
+
+    <a
+      href={tp("/")}
+      class="inline-flex items-center gap-2 rounded-lg bg-accent px-8 py-4 text-white shadow-lg transition-all duration-300 hover:bg-accent/90 hover:shadow-xl"
+    >
+      <LuHouse className="h-5 w-5" aria-hidden="true" />
+      {t("404.cta")}
+    </a>
+  </div>
+</MainLayout>
+
+<style>
+  @media (scripting: enabled) {
+    [data-animate="not-found"] {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+    [data-animate="not-found-decoration"] {
+      transform: scaleX(0);
+      transform-origin: center;
+    }
+  }
+</style>
+
+<script>
+  import { animate, inView } from "motion";
+
+  inView(
+    "[data-animate='not-found']",
+    (element) => {
+      animate(element, { opacity: 1, y: 0 }, { duration: 0.8 });
+    },
+    { margin: "-50px" }
+  );
+
+  inView("[data-animate='not-found-decoration']", (element) => {
+    animate(element, { scaleX: 1 }, { duration: 0.8, delay: 0.3 });
+  });
+</script>


### PR DESCRIPTION
Cleanup i18n patterns — fix inconsistencies, remove hacks, improve SEO correctness.

**Changes**

- Replace parity-check hack with satisfies — removed dead _enParity / _deParity variables; the ui object now uses satisfies Record<Lang, Record<TranslationKey, string>> for the same compile-time guarantee with zero unused code
- Fix stale function names in test describe blocks — useTranslations → getTranslations, useRichText → getRichText, useTranslatedPath → getTranslatedPath, getRouteFromUrl → getRoute; also fixed JSDoc example in richtext.ts
- Replace hardcoded "pl" in GROQ queries with $defaultLang parameter — all coalesce() fallbacks in Sanity queries now reference the defaultLang constant instead of a magic string
- Use absolute URLs in hreflang alternate links — getAlternateUrls() now accepts site and returns fully-qualified URLs; x-default href changed from relative "/" to absolute ${siteUrl}/
- Generate locale-specific 404 pages — moved 404 content to src/pages/[locale]/404.astro with getStaticPaths(); root 404.astro is now an SSR handler that detects locale from the URL and redirects to the appropriate localized 404